### PR TITLE
Fix hex-to-[hue, brightness]

### DIFF
--- a/kurecolor-test.el
+++ b/kurecolor-test.el
@@ -114,17 +114,23 @@
 (ert-deftest test-kurecolor-hex-get-brightness ()
   "Test getting brightness from hex."
   (skip-unless (featurep 'kurecolor))
-  (should (equal (kurecolor-hex-get-brightness "#006091") 0.5563218390804597)))
+  (should (equal (kurecolor-hex-get-brightness "#FFFFFF") 1.0))
+  (should (equal (kurecolor-hex-get-brightness "#808080") (/ 128.0 255.0)))
+  (should (equal (kurecolor-hex-get-brightness "#000000") 0.0)))
 
 (ert-deftest test-kurecolor-hex-get-saturation ()
   "Test getting saturation from hex."
   (skip-unless (featurep 'kurecolor))
-  (should (equal (kurecolor-hex-get-saturation "#006091") 1.0)))
+  (should (equal (kurecolor-hex-get-saturation "#00FF00") 1.0))
+  (should (equal (kurecolor-hex-get-saturation "#7FFF7F") (/ 128.0 255.0)))
+  (should (equal (kurecolor-hex-get-saturation "#000000") 0)))
 
 (ert-deftest test-kurecolor-hex-get-hue ()
   "Test getting hue from hex."
   (skip-unless (featurep 'kurecolor))
-  (should (equal (kurecolor-hex-get-hue "#006091") 0.5686274509803921)))
+  (should (equal (kurecolor-hex-get-hue "#FF0000") (/ 0 360.0)))
+  (should (equal (kurecolor-hex-get-hue "#00FF00") (/ 120.0 360.0)))
+  (should (equal (kurecolor-hex-get-hue "#0000FF") (/ 240.0 360.0))))
 
 (ert-deftest test-kurecolor-adjust-sat ()
   "Test adjustment of sat (saturation)."

--- a/kurecolor.el
+++ b/kurecolor.el
@@ -2,7 +2,7 @@
 
 ;;; Author: Jason Milkins <jasonm23@gmail.com>
 
-;;; Version: 1.2.5
+;;; Version: 1.2.6
 
 ;;; Commentary:
 ;;

--- a/kurecolor.el
+++ b/kurecolor.el
@@ -248,16 +248,16 @@ returns a 6 digit hex color."
   (destructuring-bind (skip sat val) (kurecolor-hex-to-hsv hex)
     (kurecolor-rgb-to-hex (kurecolor-hsv-to-rgb hue sat val))))
 
-(defun kurecolor-hex-get-brightness (hex)
-  "Get the brightness of HEX color."
+(defun kurecolor-hex-get-hue (hex)
+  "Get the hue of HEX color."
   (first (kurecolor-hex-to-hsv hex)))
 
 (defun kurecolor-hex-get-saturation (hex)
   "Get the saturation of HEX color."
   (second (kurecolor-hex-to-hsv hex)))
 
-(defun kurecolor-hex-get-hue (hex)
-  "Get the hue of HEX color."
+(defun kurecolor-hex-get-brightness (hex)
+  "Get the brightness of HEX color."
   (third (kurecolor-hex-to-hsv hex)))
 
 (defun kurecolor-hex-set-brightness (hex val)


### PR DESCRIPTION
hex-to-hue used (third) instead of (first), hex-to-brightness used (first) instead of (third)