### PR TITLE
Remove requirement on `cl` library

### DIFF
--- a/kurecolor.el
+++ b/kurecolor.el
@@ -97,7 +97,6 @@
 
 ;;; Code:
 
-(require 'cl)
 (require 's)
 
 (unless (>= (string-to-number (format "%i.%i" emacs-major-version emacs-minor-version)) 24.1)


### PR DESCRIPTION
To avoid getting the warning about usage of the deprecated `cl` library.