### PR TITLE
Simplify version check

### DIFF
--- a/kurecolor.el
+++ b/kurecolor.el
@@ -99,7 +99,7 @@
 
 (require 's)
 
-(unless (>= (string-to-number (format "%i.%i" emacs-major-version emacs-minor-version)) 24.1)
+(unless (>= emacs-major-version 24)
   (error "Requires Emacs 24.1 or later"))
 
 (unless (functionp 's-match)


### PR DESCRIPTION
There never was a 24.0; testing the major version number is thus
sufficient and avoids tedious string manipulation.